### PR TITLE
Delete recoveryKey and owner during finalizeMigration

### DIFF
--- a/contracts/IdentityManager.sol
+++ b/contracts/IdentityManager.sol
@@ -168,6 +168,8 @@ contract IdentityManager {
         delete migrationInitiated[identity];
         delete migrationNewAddress[identity];
         identity.transfer(newIdManager);
+        delete recoveryKeys[identity];
+        delete owners[identity][msg.sender];
         LogMigrationFinalized(identity, newIdManager, msg.sender);
     }
 

--- a/contracts/MetaIdentityManager.sol
+++ b/contracts/MetaIdentityManager.sol
@@ -195,6 +195,8 @@ contract MetaIdentityManager {
         delete migrationInitiated[identity];
         delete migrationNewAddress[identity];
         identity.transfer(newIdManager);
+        delete recoveryKeys[identity];
+        delete owners[identity][sender];
         LogMigrationFinalized(identity, newIdManager, sender);
     }
 

--- a/docs/identityManager.md
+++ b/docs/identityManager.md
@@ -68,8 +68,6 @@ Allows an owner to replace the Recovery Key with another one.
 
 Lets an owner initiate the process of migrating a proxy contract away from the IdentityManager to a new one. There is a time limit of `adminTimeLock` after which the migration can be finalized using `finalizeMigration`. Any owner can call `cancelMigration` at any time to cancel the migration.
 
-(TODO: Might want to fix this?) Note that once migrated away a proxy contract cannot migrate back to the IdentityManager by using `registerIdentity`.
-
 ### `isOwner`
 
 Returns true if `owner` is an owner of `identity` and is older than `userTimeLock`.

--- a/test/identityManager.js
+++ b/test/identityManager.js
@@ -548,6 +548,12 @@ contract('IdentityManager', (accounts) => {
       assert.equal(log.args.identity, proxy.address, 'finalized migrating wrong proxy')
       assert.equal(log.args.newIdManager, newIdenManager.address, 'finalized migration to wrong location')
       assert.equal(log.args.instigator, user1, 'finalized migrating from wrong person')
+
+      let isOwner = await identityManager.isOwner(proxy.address, user1, {from: user1})
+      assert.isFalse(isOwner, 'user1 should not be owner anymore')
+
+      let isRecovery = await identityManager.isRecovery(proxy.address, recoveryKey, {from: user1})
+      assert.isFalse(isRecovery, 'recoveryKey should not be recovery anymore')
     }).timeout(10000000)
 
     it('should be owner of new identityManager after successful transfer', async function() {

--- a/test/metaIdentityManager.js
+++ b/test/metaIdentityManager.js
@@ -620,6 +620,12 @@ contract('MetaIdentityManager', (accounts) => {
       assert.equal(log.args.identity, proxy.address, 'finalized migrating wrong proxy')
       assert.equal(log.args.newIdManager, newIdenManager.address, 'finalized migration to wrong location')
       assert.equal(log.args.instigator, user1, 'finalized migrating from wrong person')
+
+      let isOwner = await identityManager.isOwner(proxy.address, user1, {from: user1})
+      assert.isFalse(isOwner, 'user1 should not be owner anymore')
+
+      let isRecovery = await identityManager.isRecovery(proxy.address, recoveryKey, {from: user1})
+      assert.isFalse(isRecovery, 'recoveryKey should not be recovery anymore')
     }).timeout(10000000)
 
     it('should be owner of new identityManager after successful transfer', async function() {


### PR DESCRIPTION
This makes it possible to reregister an identity after it has been removed with the migrate feature.
