### PR TITLE
Forward call after proxy is created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ seed
 coverage.json
 test/.geth/geth
 test/.geth/history
+allFiredEvents

--- a/contracts/IdentityManager.sol
+++ b/contracts/IdentityManager.sol
@@ -96,13 +96,15 @@ contract IdentityManager {
         LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
     }
 
-
-    function createIdentitySetRegistry(address registry, uint value, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
+    /// @dev Creates a new proxy contract for an owner and recovery and allows an initial forward call which would be to set the registry in our case
+    /// @param owner Key who can use this contract to control proxy. Given full power
+    /// @param recoveryKey Key of recovery network or address from seed to recovery proxy
+    function createIdentityWithCall(address destination, uint value, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
         Proxy identity = new Proxy();
         owners[identity][owner] = now - adminTimeLock; // This is to ensure original owner has full power from day one
         recoveryKeys[identity] = recoveryKey;
         LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
-        identity.forward(registry, value, data);
+        identity.forward(destination, value, data);
     }
 
     /// @dev Allows a user to transfer control of existing proxy to this contract. Must come through proxy

--- a/contracts/IdentityManager.sol
+++ b/contracts/IdentityManager.sol
@@ -97,12 +97,12 @@ contract IdentityManager {
     }
 
 
-    function createIdentitySetRegistry(address registry, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
+    function createIdentitySetRegistry(address registry, uint value, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
         Proxy identity = new Proxy();
         owners[identity][owner] = now - adminTimeLock; // This is to ensure original owner has full power from day one
         recoveryKeys[identity] = recoveryKey;
-        identity.forward(registry, 0, data);
         LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
+        identity.forward(registry, value, data);
     }
 
     /// @dev Allows a user to transfer control of existing proxy to this contract. Must come through proxy

--- a/contracts/IdentityManager.sol
+++ b/contracts/IdentityManager.sol
@@ -97,6 +97,8 @@ contract IdentityManager {
     }
 
     /// @dev Creates a new proxy contract for an owner and recovery and allows an initial forward call which would be to set the registry in our case
+    /// @param destination Address of contract to be called after proxy is created
+    /// @param data of function to be called at the destination contract
     /// @param owner Key who can use this contract to control proxy. Given full power
     /// @param recoveryKey Key of recovery network or address from seed to recovery proxy
     function createIdentityWithCall(address destination, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {

--- a/contracts/IdentityManager.sol
+++ b/contracts/IdentityManager.sol
@@ -97,11 +97,11 @@ contract IdentityManager {
     }
 
     /// @dev Creates a new proxy contract for an owner and recovery and allows an initial forward call which would be to set the registry in our case
-    /// @param destination Address of contract to be called after proxy is created
-    /// @param data of function to be called at the destination contract
     /// @param owner Key who can use this contract to control proxy. Given full power
     /// @param recoveryKey Key of recovery network or address from seed to recovery proxy
-    function createIdentityWithCall(address destination, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
+    /// @param destination Address of contract to be called after proxy is created
+    /// @param data of function to be called at the destination contract
+    function createIdentityWithCall(address owner, address recoveryKey, address destination, bytes data) public validAddress(recoveryKey) {
         Proxy identity = new Proxy();
         owners[identity][owner] = now - adminTimeLock; // This is to ensure original owner has full power from day one
         recoveryKeys[identity] = recoveryKey;

--- a/contracts/IdentityManager.sol
+++ b/contracts/IdentityManager.sol
@@ -96,6 +96,15 @@ contract IdentityManager {
         LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
     }
 
+
+    function createIdentitySetRegistry(address registry, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
+        Proxy identity = new Proxy();
+        owners[identity][owner] = now - adminTimeLock; // This is to ensure original owner has full power from day one
+        recoveryKeys[identity] = recoveryKey;
+        identity.forward(registry, 0, data);
+        LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
+    }
+
     /// @dev Allows a user to transfer control of existing proxy to this contract. Must come through proxy
     /// @param owner Key who can use this contract to control proxy. Given full power
     /// @param recoveryKey Key of recovery network or address from seed to recovery proxy

--- a/contracts/IdentityManager.sol
+++ b/contracts/IdentityManager.sol
@@ -99,12 +99,12 @@ contract IdentityManager {
     /// @dev Creates a new proxy contract for an owner and recovery and allows an initial forward call which would be to set the registry in our case
     /// @param owner Key who can use this contract to control proxy. Given full power
     /// @param recoveryKey Key of recovery network or address from seed to recovery proxy
-    function createIdentityWithCall(address destination, uint value, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
+    function createIdentityWithCall(address destination, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
         Proxy identity = new Proxy();
         owners[identity][owner] = now - adminTimeLock; // This is to ensure original owner has full power from day one
         recoveryKeys[identity] = recoveryKey;
         LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
-        identity.forward(destination, value, data);
+        identity.forward(destination, 0, data);
     }
 
     /// @dev Allows a user to transfer control of existing proxy to this contract. Must come through proxy

--- a/contracts/MetaIdentityManager.sol
+++ b/contracts/MetaIdentityManager.sol
@@ -104,6 +104,15 @@ contract MetaIdentityManager {
         LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
     }
 
+
+    function createIdentitySetRegistry(address registry, uint value, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
+        Proxy identity = new Proxy();
+        owners[identity][owner] = now - adminTimeLock; // This is to ensure original owner has full power from day one
+        recoveryKeys[identity] = recoveryKey;
+        LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
+        identity.forward(registry, value, data);
+    }
+
     /// @dev Allows a user to transfer control of existing proxy to this contract. Must come through proxy
     /// @param owner Key who can use this contract to control proxy. Given full power
     /// @param recoveryKey Key of recovery network or address from seed to recovery proxy

--- a/contracts/MetaIdentityManager.sol
+++ b/contracts/MetaIdentityManager.sol
@@ -104,13 +104,15 @@ contract MetaIdentityManager {
         LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
     }
 
-
-    function createIdentitySetRegistry(address registry, uint value, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
+    /// @dev Creates a new proxy contract for an owner and recovery and allows an initial forward call which would be to set the registry in our case
+    /// @param owner Key who can use this contract to control proxy. Given full power
+    /// @param recoveryKey Key of recovery network or address from seed to recovery proxy
+    function createIdentityWithCall(address destination, uint value, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
         Proxy identity = new Proxy();
         owners[identity][owner] = now - adminTimeLock; // This is to ensure original owner has full power from day one
         recoveryKeys[identity] = recoveryKey;
         LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
-        identity.forward(registry, value, data);
+        identity.forward(destination, value, data);
     }
 
     /// @dev Allows a user to transfer control of existing proxy to this contract. Must come through proxy

--- a/contracts/MetaIdentityManager.sol
+++ b/contracts/MetaIdentityManager.sol
@@ -105,11 +105,11 @@ contract MetaIdentityManager {
     }
 
     /// @dev Creates a new proxy contract for an owner and recovery and allows an initial forward call which would be to set the registry in our case
-    /// @param destination Address of contract to be called after proxy is created
-    /// @param data of function to be called at the destination contract
     /// @param owner Key who can use this contract to control proxy. Given full power
     /// @param recoveryKey Key of recovery network or address from seed to recovery proxy
-    function createIdentityWithCall(address destination, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
+    /// @param destination Address of contract to be called after proxy is created
+    /// @param data of function to be called at the destination contract
+    function createIdentityWithCall(address owner, address recoveryKey, address destination, bytes data) public validAddress(recoveryKey) {
         Proxy identity = new Proxy();
         owners[identity][owner] = now - adminTimeLock; // This is to ensure original owner has full power from day one
         recoveryKeys[identity] = recoveryKey;

--- a/contracts/MetaIdentityManager.sol
+++ b/contracts/MetaIdentityManager.sol
@@ -107,12 +107,12 @@ contract MetaIdentityManager {
     /// @dev Creates a new proxy contract for an owner and recovery and allows an initial forward call which would be to set the registry in our case
     /// @param owner Key who can use this contract to control proxy. Given full power
     /// @param recoveryKey Key of recovery network or address from seed to recovery proxy
-    function createIdentityWithCall(address destination, uint value, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
+    function createIdentityWithCall(address destination, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {
         Proxy identity = new Proxy();
         owners[identity][owner] = now - adminTimeLock; // This is to ensure original owner has full power from day one
         recoveryKeys[identity] = recoveryKey;
         LogIdentityCreated(identity, msg.sender, owner,  recoveryKey);
-        identity.forward(destination, value, data);
+        identity.forward(destination, 0, data);
     }
 
     /// @dev Allows a user to transfer control of existing proxy to this contract. Must come through proxy

--- a/contracts/MetaIdentityManager.sol
+++ b/contracts/MetaIdentityManager.sol
@@ -105,6 +105,8 @@ contract MetaIdentityManager {
     }
 
     /// @dev Creates a new proxy contract for an owner and recovery and allows an initial forward call which would be to set the registry in our case
+    /// @param destination Address of contract to be called after proxy is created
+    /// @param data of function to be called at the destination contract
     /// @param owner Key who can use this contract to control proxy. Given full power
     /// @param recoveryKey Key of recovery network or address from seed to recovery proxy
     function createIdentityWithCall(address destination, bytes data, address owner, address recoveryKey) public validAddress(recoveryKey) {

--- a/test/identityManager.js
+++ b/test/identityManager.js
@@ -77,8 +77,13 @@ contract('IdentityManager', (accounts) => {
     identityManager = await IdentityManager.new(userTimeLock, adminTimeLock, adminRate)
     deployedProxy = await Proxy.new({from: user1})
     testReg = await TestRegistry.new({from: user1})
+<<<<<<< HEAD
     testNum = 1
     data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [1])
+=======
+    testNum = getRanomNumber()
+    data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [testNum])
+>>>>>>> af2f914... Add tests for createIdentitySetRegistry
     //   return snapshots.snapshot()
     // }).then(id => {
     //   snapshotId = id
@@ -110,11 +115,8 @@ contract('IdentityManager', (accounts) => {
   })
 
   it('Correctly creates Identity and calls registry set', async function() {
-    let tx = await identityManager.createIdentitySetRegistry(testReg.address, data, user1, recoveryKey, {from: nobody})
+    let tx = await identityManager.createIdentitySetRegistry(testReg.address, 0, '0x' + data, user1, recoveryKey, {from: nobody})
     let log = tx.logs[0]
-    console.log('==================')
-    console.log(log)
-    console.log('==================')
     assert.equal(log.event, 'LogIdentityCreated', 'wrong event')
 
     assert.equal(log.args.owner,
@@ -130,6 +132,10 @@ contract('IdentityManager', (accounts) => {
     await compareCode(log.args.identity, deployedProxy.address)
     let proxyOwner = await Proxy.at(log.args.identity).owner.call()
     assert.equal(proxyOwner, identityManager.address, 'Proxy owner should be the identity manager')
+    let setValue = await testReg.registry.call(log.args.identity)
+    //test that registry was set properly with testNum as the data
+    assert.equal(setValue.toNumber(), testNum)
+
   })
 
   describe('existing identity', () => {

--- a/test/identityManager.js
+++ b/test/identityManager.js
@@ -75,8 +75,6 @@ contract('IdentityManager', (accounts) => {
     identityManager = await IdentityManager.new(userTimeLock, adminTimeLock, adminRate)
     deployedProxy = await Proxy.new({from: user1})
     testReg = await TestRegistry.new({from: user1})
-    testNum = getRanomNumber()
-    data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [testNum])
     //   return snapshots.snapshot()
     // }).then(id => {
     //   snapshotId = id
@@ -110,7 +108,7 @@ contract('IdentityManager', (accounts) => {
   it('Correctly creates Identity and calls registry set', async function() {
     let testNum = getRanomNumber()
     let data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [testNum])
-    let tx = await identityManager.createIdentityWithCall(testReg.address, '0x' + data, user1, recoveryKey, {from: nobody})
+    let tx = await identityManager.createIdentityWithCall(user1, recoveryKey, testReg.address, '0x' + data, {from: nobody})
     let log = tx.logs[0]
     assert.equal(log.event, 'LogIdentityCreated', 'wrong event')
 

--- a/test/identityManager.js
+++ b/test/identityManager.js
@@ -115,7 +115,7 @@ contract('IdentityManager', (accounts) => {
   })
 
   it('Correctly creates Identity and calls registry set', async function() {
-    let tx = await identityManager.createIdentitySetRegistry(testReg.address, 0, '0x' + data, user1, recoveryKey, {from: nobody})
+    let tx = await identityManager.createIdentityWithCall(testReg.address, 0, '0x' + data, user1, recoveryKey, {from: nobody})
     let log = tx.logs[0]
     assert.equal(log.event, 'LogIdentityCreated', 'wrong event')
 

--- a/test/identityManager.js
+++ b/test/identityManager.js
@@ -56,8 +56,6 @@ contract('IdentityManager', (accounts) => {
   let user4
   let user5
   let nobody
-  let data
-  let testNum
 
   let recoveryKey
   let recoveryKey2
@@ -77,13 +75,8 @@ contract('IdentityManager', (accounts) => {
     identityManager = await IdentityManager.new(userTimeLock, adminTimeLock, adminRate)
     deployedProxy = await Proxy.new({from: user1})
     testReg = await TestRegistry.new({from: user1})
-<<<<<<< HEAD
-    testNum = 1
-    data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [1])
-=======
     testNum = getRanomNumber()
     data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [testNum])
->>>>>>> af2f914... Add tests for createIdentitySetRegistry
     //   return snapshots.snapshot()
     // }).then(id => {
     //   snapshotId = id
@@ -115,7 +108,9 @@ contract('IdentityManager', (accounts) => {
   })
 
   it('Correctly creates Identity and calls registry set', async function() {
-    let tx = await identityManager.createIdentityWithCall(testReg.address, 0, '0x' + data, user1, recoveryKey, {from: nobody})
+    let testNum = getRanomNumber()
+    let data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [testNum])
+    let tx = await identityManager.createIdentityWithCall(testReg.address, '0x' + data, user1, recoveryKey, {from: nobody})
     let log = tx.logs[0]
     assert.equal(log.event, 'LogIdentityCreated', 'wrong event')
 

--- a/test/identityManager.js
+++ b/test/identityManager.js
@@ -56,6 +56,8 @@ contract('IdentityManager', (accounts) => {
   let user4
   let user5
   let nobody
+  let data
+  let testNum
 
   let recoveryKey
   let recoveryKey2
@@ -75,6 +77,8 @@ contract('IdentityManager', (accounts) => {
     identityManager = await IdentityManager.new(userTimeLock, adminTimeLock, adminRate)
     deployedProxy = await Proxy.new({from: user1})
     testReg = await TestRegistry.new({from: user1})
+    testNum = 1
+    data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [1])
     //   return snapshots.snapshot()
     // }).then(id => {
     //   snapshotId = id
@@ -88,6 +92,29 @@ contract('IdentityManager', (accounts) => {
   it('Correctly creates Identity', async function() {
     let tx = await identityManager.createIdentity(user1, recoveryKey, {from: nobody})
     let log = tx.logs[0]
+    assert.equal(log.event, 'LogIdentityCreated', 'wrong event')
+
+    assert.equal(log.args.owner,
+                 user1,
+                 'Owner key is set in event')
+    assert.equal(log.args.recoveryKey,
+                 recoveryKey,
+                 'Recovery key is set in event')
+    assert.equal(log.args.creator,
+                 nobody,
+                 'Creator is set in event')
+
+    await compareCode(log.args.identity, deployedProxy.address)
+    let proxyOwner = await Proxy.at(log.args.identity).owner.call()
+    assert.equal(proxyOwner, identityManager.address, 'Proxy owner should be the identity manager')
+  })
+
+  it('Correctly creates Identity and calls registry set', async function() {
+    let tx = await identityManager.createIdentitySetRegistry(testReg.address, data, user1, recoveryKey, {from: nobody})
+    let log = tx.logs[0]
+    console.log('==================')
+    console.log(log)
+    console.log('==================')
     assert.equal(log.event, 'LogIdentityCreated', 'wrong event')
 
     assert.equal(log.args.owner,

--- a/test/metaIdentityManager.js
+++ b/test/metaIdentityManager.js
@@ -120,7 +120,7 @@ contract('MetaIdentityManager', (accounts) => {
   })
 
   it('Correctly creates Identity and calls registry set', async function() {
-    let tx = await identityManager.createIdentitySetRegistry(testReg.address, 0, '0x' + data, user1, recoveryKey, {from: nobody})
+    let tx = await identityManager.createIdentityWithCall(testReg.address, 0, '0x' + data, user1, recoveryKey, {from: nobody})
     let log = tx.logs[0]
     assert.equal(log.event, 'LogIdentityCreated', 'wrong event')
 

--- a/test/metaIdentityManager.js
+++ b/test/metaIdentityManager.js
@@ -120,7 +120,7 @@ contract('MetaIdentityManager', (accounts) => {
   it('Correctly creates Identity and calls registry set', async function() {
     let testNum = getRandomNumber()
     let data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [testNum])
-    let tx = await identityManager.createIdentityWithCall(testReg.address, '0x' + data, user1, recoveryKey, {from: nobody})
+    let tx = await identityManager.createIdentityWithCall(user1, recoveryKey, testReg.address, '0x' + data, {from: nobody})
     let log = tx.logs[0]
     assert.equal(log.event, 'LogIdentityCreated', 'wrong event')
 

--- a/test/metaIdentityManager.js
+++ b/test/metaIdentityManager.js
@@ -101,8 +101,6 @@ contract('MetaIdentityManager', (accounts) => {
     identityManager = await MetaIdentityManager.new(userTimeLock, adminTimeLock, adminRate, relay)
     deployedProxy = await Proxy.new({from: user1})
     testReg = await TestRegistry.new({from: user1})
-    testNum = getRandomNumber()
-    data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [testNum])
   })
 
   it('Correctly creates Identity', async function() {
@@ -120,7 +118,9 @@ contract('MetaIdentityManager', (accounts) => {
   })
 
   it('Correctly creates Identity and calls registry set', async function() {
-    let tx = await identityManager.createIdentityWithCall(testReg.address, 0, '0x' + data, user1, recoveryKey, {from: nobody})
+    let testNum = getRandomNumber()
+    let data = lightwallet.txutils._encodeFunctionTxData('register', ['uint256'], [testNum])
+    let tx = await identityManager.createIdentityWithCall(testReg.address, '0x' + data, user1, recoveryKey, {from: nobody})
     let log = tx.logs[0]
     assert.equal(log.event, 'LogIdentityCreated', 'wrong event')
 


### PR DESCRIPTION
New function - `createIdentityWithCall`

- Creates a proxy contract, sets owner & recoveryKey
- Forwards one call to the proxy, in our case this would be to set the proxy -> ipfs hash in registry