### PR TITLE
Declare a specific choice for the IdentityManager constants

### DIFF
--- a/docs/identityManager.md
+++ b/docs/identityManager.md
@@ -88,9 +88,7 @@ _adminTimeLock - Time before new owner can add/remove owners
 _adminRate - Time period used for rate limiting a given key for admin functionality
 ```
 
-There are two options we are exploring right now. The first option is to set these three values to zero. This allows us to use the core functionality of the contracts while not having to conosider any of the complexity in terms of UI/UX to handle all of the timelock rules initially. We will likely not implement the functions that check if your identity is being attacked right away, therefore there is little need to have the timelock anyway. Once we are ready to take the step to add these features to the mobile app we can prompt the users to migrate to the new instances of IdentityManager.
-
-The other option is to use the values specified below. These are also the values we think should be used if migrating from the option above.
+The values we have chosen for these constants are given below.
 
 |Constant|Value|
 | --|--|

--- a/migrations/2_deploy_identity_managers.js
+++ b/migrations/2_deploy_identity_managers.js
@@ -2,10 +2,9 @@ const IdentityManager = artifacts.require('./IdentityManager.sol')
 const TxRelay = artifacts.require('./TxRelay.sol')
 const MetaIdentityManager = artifacts.require('./MetaIdentityManager.sol')
 
-// TODO - specify these constants. They should also probably be different for different networks.
-const USER_TIME_LOCK = 0;
-const ADMIN_TIME_LOCK = 0;
-const ADMIN_RATE = 0;
+const USER_TIME_LOCK = 3600
+const ADMIN_TIME_LOCK = 129600
+const ADMIN_RATE = 1200
 
 module.exports = async function (deployer) {
   await deployer.deploy(IdentityManager, USER_TIME_LOCK, ADMIN_TIME_LOCK, ADMIN_RATE)


### PR DESCRIPTION
fix #62

We choose the constants in IdentityManager and MetaIdentityManager to be:

|Constant|Value|
| --|--|
|_userTimeLock|3600 (1 hour)|
|_adminTimeLock|129600 (1.5 days)|
|_adminRate|1200 (20 minutes)|

Rationale as from doc:

> These values gives an OlderOwner the ability to recover from a stolen recoveryKey. If a stolen recoveryKey is used to add a user, that user will be able to transact from the proxy after 1 h, but won't be able to remove other users etc until 1.5 days have passed. An adminRate of 20 minutes gives the admin enought time to first remove the stolen recoveryKey and then remove the malicious owner added by the stolen recoveryKey before the new owner will become an OlderOwner. The adminRate simply limits the amount of "admin actions" an OlderOwner can make in a given time period. So for example if the OlderOwner adds a new owner, it can't remove that owner until adminRate has passed. The recoveryKey is also affected by this rate and can only add new owners at a rate of adminRate.
