### PR TITLE
Feature/ch4921/whitelisted tx relay

### DIFF
--- a/contracts/TxRelay.sol
+++ b/contracts/TxRelay.sol
@@ -36,8 +36,8 @@ contract TxRelay {
 
         address claimedSender = getAddress(data);
         // use EIP 191
-        // 0x19 :: version :: relay :: nonce :: destination :: data :: whitelist
-        bytes32 h = keccak256(byte(0x19), byte(0), this, nonce[claimedSender], destination, data, listNum);
+        // 0x19 :: version :: relay :: whitelist :: nonce :: destination :: data
+        bytes32 h = keccak256(byte(0x19), byte(0), this, listNum, nonce[claimedSender], destination, data);
         address addressFromSig = ecrecover(h, sigV, sigR, sigS);
 
         require(claimedSender == addressFromSig);
@@ -76,39 +76,39 @@ contract TxRelay {
      * @dev Adds a number of addresses to a specific whitelist. Only
      * the owner of a whitelist can add to it.
      * @param listNum The list number
-     * @param allowedSenders the addresses to add to the whitelist
+     * @param sendersToUpdate the addresses to add to the whitelist
      */
-    function addToWhitelist(uint listNum, address[] allowedSenders) public {
+    function addToWhitelist(uint listNum, address[] sendersToUpdate) public {
         if (listOwner[listNum] == 0x0) {
             listOwner[listNum] = msg.sender;
         }
-        updateWhitelist(listNum, allowedSenders, true);
+        updateWhitelist(listNum, sendersToUpdate, true);
     }
 
     /*
      * @dev Removes a number of addresses from a specific whitelist. Only
      * the owner of a whitelist can remove from it.
      * @param listNum The list number
-     * @param allowedSenders the addresses to add to the whitelist
+     * @param sendersToUpdate the addresses to add to the whitelist
      */
-    function removeFromWhitelist(uint listNum, address[] allowedSenders) public {
-        updateWhitelist(listNum, allowedSenders, false);
+    function removeFromWhitelist(uint listNum, address[] sendersToUpdate) public {
+        updateWhitelist(listNum, sendersToUpdate, false);
     }
 
     /*
      * @dev Internal logic to update a whitelist
      * @param listNum The list number
-     * @param allowedSenders the addresses to add to the whitelist
-     * @param onList whether to add or remove addresses
+     * @param sendersToUpdate the addresses to add to the whitelist
+     * @param newStatus whether to add or remove addresses
      */
-    function updateWhitelist(uint listNum, address[] allowedSenders, bool onList) private {
+    function updateWhitelist(uint listNum, address[] sendersToUpdate, bool newStatus) private {
         // list 0 can not be owned
         require(listNum != 0);
         // list must be owned by msg.sender
         require(listOwner[listNum] == msg.sender);
 
-        for (uint i = 0; i < allowedSenders.length; i++) {
-            whitelist[listNum][allowedSenders[i]] = onList;
+        for (uint i = 0; i < sendersToUpdate.length; i++) {
+            whitelist[listNum][sendersToUpdate[i]] = newStatus;
         }
     }
 }

--- a/contracts/TxRelay.sol
+++ b/contracts/TxRelay.sol
@@ -10,6 +10,10 @@ contract TxRelay {
     // Different from the nonce defined w/in protocol.
     mapping(address => uint) nonce;
 
+    event LogTxFailed(
+        address indexed destination,
+        bytes data);
+
     /*
      * @dev Relays meta transactions
      * @param sigV, sigR, sigS ECDSA signature on some data to be forwarded
@@ -37,7 +41,7 @@ contract TxRelay {
         nonce[claimedSender]++; //if we are going to do tx, update nonce
 
         if (!destination.call(data)) {
-            //In the future, add event here. Has semi-complex gas considerations. See EIP 150
+            LogTxFailed(destination, data);
         }
     }
 

--- a/contracts/TxRelay.sol
+++ b/contracts/TxRelay.sol
@@ -10,10 +10,6 @@ contract TxRelay {
     // Different from the nonce defined w/in protocol.
     mapping(address => uint) nonce;
 
-    event LogTxFailed(
-        address indexed destination,
-        bytes data);
-
     /*
      * @dev Relays meta transactions
      * @param sigV, sigR, sigS ECDSA signature on some data to be forwarded
@@ -40,9 +36,7 @@ contract TxRelay {
 
         nonce[claimedSender]++; //if we are going to do tx, update nonce
 
-        if (!destination.call(data)) {
-            LogTxFailed(destination, data);
-        }
+        require(destination.call(data));
     }
 
     /*

--- a/contracts/TxRelay.sol
+++ b/contracts/TxRelay.sol
@@ -10,6 +10,11 @@ contract TxRelay {
     // Different from the nonce defined w/in protocol.
     mapping(address => uint) nonce;
 
+    // This mapping specifies a whitelist of allowed senders for transactions.
+    // There can be one whitelist per ethereum account, which is the owner of that
+    // whitelist. Users can specify which whitelist they want to use when signing
+    // a transaction. They can use their own whitelist, a whitelist belonging
+    // to another account, or skip using a whitelist by specifying the zero address.
     mapping(address => mapping(address => bool)) public whitelist;
 
     /*

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "directory-tree": "^2.0.0",
     "eth-lightwallet": "^2.5.6",
     "eth-signer": "^0.2.2",
-    "ethereumjs-testrpc": "^3.0.3",
+    "ethereumjs-testrpc": "^6.0.3",
     "ethjs-abi": "^0.1.9",
     "node-plantuml": "^0.5.0",
     "solidity-coverage": "^0.1.7",

--- a/test/identityManager.js
+++ b/test/identityManager.js
@@ -38,7 +38,7 @@ async function testForwardTo(testReg, identityManager, proxyAddress, fromAccount
     assert.isNotOk(errorThrown, 'An error should not have been thrown')
     assert.equal(regData.toNumber(), testNum)
   } else {
-    //assert.match(errorThrown, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+    //assert.match(errorThrown, /VM Exception while processing transaction: revert/, 'throws an error')
     assertThrown(errorThrown, 'throws an error')
     assert.notEqual(regData.toNumber(), testNum)
   }
@@ -181,7 +181,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.addOwner(proxy.address, user4, {from: user1})
       } catch (e) {
-        assert.match(e.message, /invalid opcode/, "should have thrown")
+        assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -190,7 +190,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.removeOwner(proxy.address, user5, {from: user1})
       } catch (e) {
-        assert.match(e.message, /invalid opcode/, "should have thrown")
+        assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -199,7 +199,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.changeRecovery(proxy.address, recoveryKey2, {from: user1})
       } catch (e) {
-        assert.match(e.message, /invalid opcode/, "should have thrown")
+        assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -214,7 +214,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.removeOwner(proxy.address, user5, {from: user1})
       } catch (e) {
-        assert.match(e.message, /invalid opcode/, "should have thrown")
+        assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -223,7 +223,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.changeRecovery(proxy.address, recoveryKey2, {from: user1})
       } catch (e) {
-        assert.match(e.message, /invalid opcode/, "should have thrown")
+        assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -237,7 +237,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.changeRecovery(proxy.address, recoveryKey2, {from: user1})
       } catch (e) {
-        assert.match(e.message, /invalid opcode/, "should have thrown")
+        assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -252,7 +252,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.addOwner(proxy.address, user4, {from: user3})
       } catch(error) {
-        assert.match(error.message, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+        assert.match(error.message, /VM Exception while processing transaction: revert/, 'throws an error')
       }
     })
 
@@ -273,7 +273,7 @@ contract('IdentityManager', (accounts) => {
         try {
           await identityManager.addOwner(proxy.address, user4, {from: user2})
         } catch(error) {
-          assert.match(error.message, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+          assert.match(error.message, /VM Exception while processing transaction: revert/, 'throws an error')
         }
       })
 
@@ -281,7 +281,7 @@ contract('IdentityManager', (accounts) => {
         try {
           await identityManager.removeOwner(proxy.address, user1, {from: user2})
         } catch(error) {
-          assert.match(error.message, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+          assert.match(error.message, /VM Exception while processing transaction: revert/, 'throws an error')
         }
       })
 
@@ -289,7 +289,7 @@ contract('IdentityManager', (accounts) => {
         try {
           await identityManager.changeRecovery(proxy.address, recoveryKey2, {from: user2})
         } catch(error) {
-          assert.match(error.message, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+          assert.match(error.message, /VM Exception while processing transaction: revert/, 'throws an error')
         }
       })
 
@@ -365,7 +365,7 @@ contract('IdentityManager', (accounts) => {
           try {
             await identityManager.changeRecovery(proxy.address, ZERO_ADDRESS, {from: user1})
           } catch (e) {
-            assert.match(e.message, /invalid opcode/, "should have thrown")
+            assert.match(e.message, /revert/, "should have thrown")
             errorThrown = true
           }
           assertThrown(errorThrown, "should have thrown")
@@ -432,7 +432,7 @@ contract('IdentityManager', (accounts) => {
         try {
           await identityManager.addOwnerFromRecovery(proxy.address, user4, {from: nobody})
         } catch (e) {
-          assert.match(e.message, /invalid opcode/, "should have thrown")
+          assert.match(e.message, /revert/, "should have thrown")
           errorThrown = true
         }
         assertThrown(errorThrown, "should have thrown")
@@ -444,7 +444,7 @@ contract('IdentityManager', (accounts) => {
         try {
           await identityManager.addOwnerFromRecovery(proxy.address, user2, {from: recoveryKey})
         } catch (e) {
-          assert.match(e.message, /invalid opcode/, "should have thrown")
+          assert.match(e.message, /revert/, "should have thrown")
           errorThrown = true
         }
         assertThrown(errorThrown, "should have thrown")
@@ -483,7 +483,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.initiateMigration(proxy.address, newIdenManager.address, {from: user2})
       } catch(error) {
-        assert.match(error.message, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+        assert.match(error.message, /VM Exception while processing transaction: revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'Should have thrown an error here')
@@ -494,7 +494,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.initiateMigration(proxy.address, newIdenManager.address, {from: nobody})
       } catch(error) {
-        assert.match(error.message, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+        assert.match(error.message, /VM Exception while processing transaction: revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'Should have thrown an error here')
@@ -539,7 +539,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.cancelMigration(proxy.address, {from: nobody})
       } catch(error) {
-        assert.match(error.message, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+        assert.match(error.message, /VM Exception while processing transaction: revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'Should have thrown error')
@@ -557,7 +557,7 @@ contract('IdentityManager', (accounts) => {
       try {
           await identityManager.finalizeMigration(proxy.address, {from: nobody})
       } catch(error) {
-        assert.match(error.message, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+        assert.match(error.message, /VM Exception while processing transaction: revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'non-owner should not be able to finalize')
@@ -565,7 +565,7 @@ contract('IdentityManager', (accounts) => {
       try {
           await identityManager.finalizeMigration(proxy.address, {from: user2})
       } catch(error) {
-        assert.match(error.message, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+        assert.match(error.message, /VM Exception while processing transaction: revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'young owner should not be able to finalize')
@@ -575,7 +575,7 @@ contract('IdentityManager', (accounts) => {
       try {
           await identityManager.finalizeMigration(proxy.address, {from: user1})
       } catch(error) {
-        assert.match(error.message, /VM Exception while processing transaction: invalid opcode/, 'throws an error')
+        assert.match(error.message, /VM Exception while processing transaction: revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'older owner should not be able to finalize before time is up')
@@ -620,7 +620,7 @@ contract('IdentityManager', (accounts) => {
       try {
         await identityManager.forwardTo(proxy.address, identityManager.address, 0, data, {from: user1})
       } catch(e) {
-        assert.match(e.message, /invalid opcode/, 'throws an error')
+        assert.match(e.message, /revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'existing proxy should not be able to re-register')

--- a/test/identityManager.js
+++ b/test/identityManager.js
@@ -326,7 +326,7 @@ contract('IdentityManager', (accounts) => {
           try {
             await identityManager.removeOwner(proxy.address, user2, {from: user2})
           } catch (e) {
-            assert.match(e.message, /invalid opcode/, "should have thrown")
+            assert.match(e.message, /revert/, "should have thrown")
             errorThrown = true
           }
           assertThrown(errorThrown, "should have thrown")

--- a/test/metaIdentityManager.js
+++ b/test/metaIdentityManager.js
@@ -382,7 +382,7 @@ contract('MetaIdentityManager', (accounts) => {
           try {
             await identityManager.removeOwner(user2, proxy.address, user2, {from: user2})
           } catch (e) {
-            assert.match(e.message, /invalid opcode/, "should have thrown")
+            assert.match(e.message, /revert/, "should have thrown")
             errorThrown = true
           }
           assertThrown(errorThrown, "should have thrown")

--- a/test/metaIdentityManager.js
+++ b/test/metaIdentityManager.js
@@ -39,7 +39,7 @@ async function testForwardTo(testReg, identityManager, proxyAddress, fromAccount
     assert.isNotOk(errorThrown, 'An error should not have been thrown')
     assert.equal(regData.toNumber(), testNum)
   } else {
-    //assert.match(errorThrown, /invalid opcode/, 'throws an error')
+    //assert.match(errorThrown, /revert/, 'throws an error')
     assertThrown(errorThrown, 'throws an error')
     assert.notEqual(regData.toNumber(), testNum)
   }
@@ -62,7 +62,7 @@ async function testForwardToFromRelay(testReg, identityManager, proxyAddress, fr
     assert.isNotOk(errorThrown, 'An error should not have been thrown')
     assert.equal(regData.toNumber(), testNum)
   } else {
-    //assert.match(errorThrown, /invalid opcode/, 'throws an error')
+    //assert.match(errorThrown, /revert/, 'throws an error')
     assertThrown(errorThrown, 'throws an error')
     assert.notEqual(regData.toNumber(), testNum)
   }
@@ -185,7 +185,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.forwardTo('0x0', '0x0', '0x0', 0, '0x0', {from: relay})
       } catch (e) {
-        assert.match(e.message, /invalid opcode/, "Should have thrown")
+        assert.match(e.message, /revert/, "Should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown an error")
@@ -220,7 +220,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.addOwner(user1, proxy.address, user4, {from: user1})
       } catch (e) {
-        //assert.match(e.message, /invalid opcode/, "should have thrown")
+        //assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -229,7 +229,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.removeOwner(user1, proxy.address, user5, {from: user1})
       } catch (e) {
-        //assert.match(e.message, /invalid opcode/, "should have thrown")
+        //assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -238,7 +238,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.changeRecovery(user1, proxy.address, recoveryKey2, {from: user1})
       } catch (e) {
-        //assert.match(e.message, /invalid opcode/, "should have thrown")
+        //assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -253,7 +253,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.removeOwner(user1, proxy.address, user5, {from: user1})
       } catch (e) {
-        //assert.match(e.message, /invalid opcode/, "should have thrown")
+        //assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -262,7 +262,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.changeRecovery(user1, proxy.address, recoveryKey2, {from: user1})
       } catch (e) {
-        //assert.match(e.message, /invalid opcode/, "should have thrown")
+        //assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -276,7 +276,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.changeRecovery(user1, proxy.address, recoveryKey2, {from: user1})
       } catch (e) {
-        //assert.match(e.message, /invalid opcode/, "should have thrown")
+        //assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -292,7 +292,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.addOwner(user3, proxy.address, user4, {from: user3})
       } catch(e) {
-        //assert.match(e.message, /invalid opcode/, 'throws an error')
+        //assert.match(e.message, /revert/, 'throws an error')
         errorThrown = true
       }
       assertThrown(errorThrown, "should have thrown")
@@ -320,7 +320,7 @@ contract('MetaIdentityManager', (accounts) => {
         try {
           await identityManager.addOwner(user2, proxy.address, user4, {from: user2})
         } catch(e) {
-          //assert.match(e.message, /invalid opcode/, 'throws an error')
+          //assert.match(e.message, /revert/, 'throws an error')
           errorThrown = true
         }
         assertThrown(errorThrown, 'Should have thrown')
@@ -331,7 +331,7 @@ contract('MetaIdentityManager', (accounts) => {
         try {
           await identityManager.removeOwner(user2, proxy.address, user1, {from: user2})
         } catch(e) {
-          //assert.match(e.message, /invalid opcode/, 'throws an error')
+          //assert.match(e.message, /revert/, 'throws an error')
           errorThrown = true
         }
         assertThrown(errorThrown, 'Should have thrown')
@@ -342,7 +342,7 @@ contract('MetaIdentityManager', (accounts) => {
         try {
           await identityManager.changeRecovery(user2, proxy.address, recoveryKey2, {from: user2})
         } catch(e) {
-          //assert.match(e.message, /invalid opcode/, 'throws an error')
+          //assert.match(e.message, /revert/, 'throws an error')
           errorThrown = true
         }
         assertThrown(errorThrown, 'Should have thrown')
@@ -421,7 +421,7 @@ contract('MetaIdentityManager', (accounts) => {
           try {
             await identityManager.changeRecovery(user2, proxy.address, ZERO_ADDRESS, {from: user2})
           } catch (e) {
-            //assert.match(e.message, /invalid opcode/, "should have thrown")
+            //assert.match(e.message, /revert/, "should have thrown")
             errorThrown = true
           }
           assertThrown(errorThrown, "should have thrown")
@@ -440,7 +440,7 @@ contract('MetaIdentityManager', (accounts) => {
         try {
           tx = await identityManager.addOwnerFromRecovery(recoveryKey, proxy.address, user4, {from: recoveryKey})
         } catch (e) {
-          //assert.match(e.message, /invalid opcode/, "should have thrown")
+          //assert.match(e.message, /revert/, "should have thrown")
           errorThrown = true
         }
         assertThrown(errorThrown, "should have thrown")
@@ -504,7 +504,7 @@ contract('MetaIdentityManager', (accounts) => {
         try {
           await identityManager.addOwnerFromRecovery(nobody, proxy.address, user4, {from: nobody})
         } catch (e) {
-          //assert.match(e.message, /invalid opcode/, "should have thrown")
+          //assert.match(e.message, /revert/, "should have thrown")
           errorThrown = true
         }
         assertThrown(errorThrown, "should have thrown")
@@ -516,7 +516,7 @@ contract('MetaIdentityManager', (accounts) => {
         try {
           await identityManager.addOwnerFromRecovery(recoveryKey, proxy.address, user2, {from: recoveryKey})
         } catch (e) {
-          //assert.match(e.message, /invalid opcode/, "should have thrown")
+          //assert.match(e.message, /revert/, "should have thrown")
           errorThrown = true
         }
         assertThrown(errorThrown, "should have thrown")
@@ -555,7 +555,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.initiateMigration(user2, proxy.address, newIdenManager.address, {from: user2})
       } catch(e) {
-        //assert.match(e.message, /invalid opcode/, 'throws an error')
+        //assert.match(e.message, /revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'Should have thrown an error here')
@@ -566,7 +566,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.initiateMigration(nobody, proxy.address, newIdenManager.address, {from: nobody})
       } catch(e) {
-        //assert.match(e.message, /invalid opcode/, 'throws an error')
+        //assert.match(e.message, /revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'Should have thrown an error here')
@@ -611,7 +611,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.cancelMigration(nobody, proxy.address, {from: nobody})
       } catch(e) {
-        //assert.match(e.message, /invalid opcode/, 'throws an error')
+        //assert.match(e.message, /revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'Should have thrown error')
@@ -629,7 +629,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
           await identityManager.finalizeMigration(nobody, proxy.address, {from: nobody})
       } catch(e) {
-        //assert.match(e.message, /invalid opcode/, 'throws an error')
+        //assert.match(e.message, /revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'non-owner should not be able to finalize')
@@ -637,7 +637,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
           await identityManager.finalizeMigration(user2, proxy.address, {from: user2})
       } catch(e) {
-        //assert.match(e.message, /invalid opcode/, 'throws an error')
+        //assert.match(e.message, /revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'young owner should not be able to finalize')
@@ -647,7 +647,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
           await identityManager.finalizeMigration(user1, proxy.address, {from: user1})
       } catch(e) {
-        //assert.match(e.message, /invalid opcode/, 'throws an error')
+        //assert.match(e.message, /revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'young owner should not be able to finalize')
@@ -693,7 +693,7 @@ contract('MetaIdentityManager', (accounts) => {
       try {
         await identityManager.forwardTo(user1, proxy.address, identityManager.address, 0, data, {from: user1})
       } catch(e) {
-        //assert.match(e.message, /invalid opcode/, 'throws an error')
+        //assert.match(e.message, /revert/, 'throws an error')
         threwError = true
       }
       assertThrown(threwError, 'existing proxy should not be able to re-register')

--- a/test/txRelay.js
+++ b/test/txRelay.js
@@ -225,7 +225,10 @@ contract('TxRelay', (accounts) => {
       tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data,
                                     {from: sender, gas: 4500000})
       //Best way I have found to test for throw in a sub-call. Suggestions welcome :)
-      assert.isAbove(tx.receipt.gasUsed, 4000000, "Did not throw, as it should have consumed gas")
+      //assert.isAbove(tx.receipt.gasUsed, 4000000, "Did not throw, as it should have consumed gas")
+      let event = tx.logs[0]
+      assert.equal(event.event, 'LogTxFailed')
+      assert.equal(event.args.destination, p.dest)
 
       p = await signPayload(user1, sender, txRelay, mTestReg.address, 'testThrow',
                             types, params, lw, keyFromPw)
@@ -366,7 +369,9 @@ contract('TxRelay', (accounts) => {
                               'addOwner', types, params, lw, keyFromPw)
 
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender, gas: 4500000})
-        assert.isAbove(tx.receipt.gasUsed, 4000000, "Should have thrown in a sub call")
+        let event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
 
         //Tries to change the recoveryKey
         params = [user1, proxy.address, recoveryKey2]
@@ -374,7 +379,9 @@ contract('TxRelay', (accounts) => {
                               'changeRecovery', types, params, lw, keyFromPw)
 
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender, gas: 4500000})
-        assert.isAbove(tx.receipt.gasUsed, 4000000, "Should have thrown in a sub call")
+        event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
 
         //Then have user1 try to remove user2 - still is rateLimited
         params = [user1, proxy.address, user2]
@@ -382,7 +389,9 @@ contract('TxRelay', (accounts) => {
                               'removeOwner', types, params, lw, keyFromPw)
 
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
-        assert.isAbove(tx.receipt.gasUsed, 4000000, "Should have thrown in a sub call")
+        event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
 
         //Make them no longer rateLimited
         await evm_increaseTime(adminRate + 1)
@@ -400,7 +409,9 @@ contract('TxRelay', (accounts) => {
                               'removeOwner', types, params, lw, keyFromPw)
 
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender, gas: 4500000})
-        assert.isAbove(tx.receipt.gasUsed, 4000000, "Should have thrown in a sub call")
+        event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
 
         //Tries to change the recoveryKey
         params = [user1, proxy.address, recoveryKey2]
@@ -408,7 +419,9 @@ contract('TxRelay', (accounts) => {
                               'changeRecovery', types, params, lw, keyFromPw)
 
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender, gas: 4500000})
-        assert.isAbove(tx.receipt.gasUsed, 4000000, "Should have thrown in a sub call")
+        event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
 
         //Unrate limit them again
         await evm_increaseTime(adminRate + 1)
@@ -426,7 +439,9 @@ contract('TxRelay', (accounts) => {
                               'changeRecovery', types, params, lw, keyFromPw)
 
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender, gas: 4500000})
-        assert.isAbove(tx.receipt.gasUsed, 4000000, "Should have thrown in a sub call")
+        event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
 
         //Unrate limit them again
         await evm_increaseTime(adminRate + 1)
@@ -449,7 +464,9 @@ contract('TxRelay', (accounts) => {
         assert.equal(res, user3, "Address is not first parameter")
 
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
-        assert.isUndefined(tx.receipt.logs[0], "Generated logs, thus owner was added")
+        let event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
       })
 
       describe("new owner added by owner", () => {
@@ -489,7 +506,9 @@ contract('TxRelay', (accounts) => {
             assert.equal(res, user2, "Address is not first parameter")
 
             tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
-            assert.isUndefined(tx.receipt.logs[0], "Generated logs, thus owner was added")
+            let event = tx.logs[0]
+            assert.equal(event.event, 'LogTxFailed')
+            assert.equal(event.args.destination, p.dest)
           })
 
           it("can not remove other owner yet", async function () {
@@ -502,7 +521,9 @@ contract('TxRelay', (accounts) => {
             assert.equal(res, user2, "Address is not first parameter")
 
             tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
-            assert.isUndefined(tx.receipt.logs[0], "Generated logs, thus owner was removed")
+            let event = tx.logs[0]
+            assert.equal(event.event, 'LogTxFailed')
+            assert.equal(event.args.destination, p.dest)
           })
 
           it("can not change recoveryKey yet", async function () {
@@ -515,7 +536,9 @@ contract('TxRelay', (accounts) => {
             assert.equal(res, user2, "Address is not first parameter")
 
             tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
-            assert.isUndefined(tx.receipt.logs[0], "Generated logs, thus recovery was changed")
+            let event = tx.logs[0]
+            assert.equal(event.event, 'LogTxFailed')
+            assert.equal(event.args.destination, p.dest)
           })
         })
 
@@ -577,7 +600,9 @@ contract('TxRelay', (accounts) => {
                                 'addOwnerFromRecovery', types, params, lw, keyFromPw)
 
           tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender, gas: 4500000})
-          assert.isAbove(tx.receipt.gasUsed, 4000000, "Sub call should have thrown")
+          let event = tx.logs[0]
+          assert.equal(event.event, 'LogTxFailed')
+          assert.equal(event.args.destination, p.dest)
         })
 
         it("within userTimeLock is not allowed transactions", async function () {
@@ -668,7 +693,9 @@ contract('TxRelay', (accounts) => {
                               'initiateMigration', types, params, lw, keyFromPw)
 
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
-        assert.isUndefined(tx.receipt.logs[0], "Log generated, so therefore transfer started")
+        let event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
       })
 
       it("non-owner should not be able to start transfer", async function () {
@@ -678,7 +705,9 @@ contract('TxRelay', (accounts) => {
                               'initiateMigration', types, params, lw, keyFromPw)
 
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
-        assert.isUndefined(tx.receipt.logs[0], "Log generated, so therefore transfer started")
+        let event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
       })
 
       it("correct keys can cancel migration ", async function () {
@@ -696,7 +725,9 @@ contract('TxRelay', (accounts) => {
         p = await signPayload(user3, sender, txRelay, identityManager.address,
                               'cancelMigration', types, params, lw, keyFromPw)
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
-        assert.isUndefined(tx.receipt.logs[0], "Log generated, so therefore transfer started")
+        let event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
 
         //Young owner tries to cancel
         params = [user2, proxy.address]
@@ -739,14 +770,18 @@ contract('TxRelay', (accounts) => {
         p = await signPayload(user3, sender, txRelay, identityManager.address,
                               'finalizeMigration', types, params, lw, keyFromPw)
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
-        assert.isUndefined(tx.receipt.logs[0], "Log generated, so therefore transfer started")
+        let event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
 
         //Young owner tries to finalize
         params = [user2, proxy.address]
         p = await signPayload(user2, sender, txRelay, identityManager.address,
                               'finalizeMigration', types, params, lw, keyFromPw)
         tx = await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
-        assert.isUndefined(tx.receipt.logs[0], "Log generated, so therefore transfer started")
+        event = tx.logs[0]
+        assert.equal(event.event, 'LogTxFailed')
+        assert.equal(event.args.destination, p.dest)
 
         await evm_increaseTime(adminTimeLock + 1)
 

--- a/test/txRelay.js
+++ b/test/txRelay.js
@@ -101,7 +101,7 @@ async function testMetaTxForwardTo(signingAddr, sendingAddr, txRelay, identityMa
     await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sendingAddr})
   } catch (error) {
     errorThrown = true
-    //assert.match(error, /invalid opcode/, "An error should have been thrown")
+    //assert.match(error, /revert/, "An error should have been thrown")
   }
   let regData = await testReg.registry.call(proxyAddress)
   if (relayShouldFail) {
@@ -247,7 +247,7 @@ contract('TxRelay', (accounts) => {
         //claim to be a different person again
         await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
       } catch (e) {
-        assert.match(e.message, /invalid opcode/, "Should have thrown")
+        assert.match(e.message, /revert/, "Should have thrown")
         errorThrown = true;
       }
       assertThrown(errorThrown, "Has thrown an error")
@@ -300,7 +300,7 @@ contract('TxRelay', (accounts) => {
         //Relayer tries to relay the same transaction twice
         await txRelay.relayMetaTx(p.v, p.r, p.s, p.dest, p.data, {from: sender})
       } catch (e) {
-        assert.match(e.message, /invalid opcode/, "should have thrown")
+        assert.match(e.message, /revert/, "should have thrown")
         errorThrown = true
       }
       assertThrown(errorThrown, "Should have thrown")

--- a/test/txRelay.js
+++ b/test/txRelay.js
@@ -388,13 +388,13 @@ contract('TxRelay', (accounts) => {
     })
 
     it("Should allow another sender to create their own whitelist", async () => {
-      await testTxRelay.addToWhitelist([sender5, sender6], {from: sender2})
+      await testTxRelay.addToWhitelist([sender6, sender7], {from: sender2})
 
       assert.isFalse(await testTxRelay.whitelist.call(sender2, sender2), "sender2 should not be on list")
       assert.isFalse(await testTxRelay.whitelist.call(sender2, sender3), "sender3 should not be on list")
       assert.isFalse(await testTxRelay.whitelist.call(sender2, sender4), "sender4 should not be on list")
-      assert.isTrue(await testTxRelay.whitelist.call(sender2, sender5), "sender5 should be on list")
       assert.isTrue(await testTxRelay.whitelist.call(sender2, sender6), "sender6 should be on list")
+      assert.isTrue(await testTxRelay.whitelist.call(sender2, sender7), "sender7 should be on list")
     })
 
     it("Should send tx if sender is in whitelist", async () => {

--- a/test/txRelay.js
+++ b/test/txRelay.js
@@ -66,8 +66,8 @@ async function signPayload(signingAddr, sendingAddr, txRelay, destinationAddress
 
    nonce = await txRelay.getNonce.call(signingAddr)
    //Tight packing, as Solidity sha3 does
-   hashInput = '0x1900' + txRelay.address.slice(2) + pad(nonce.toString('16')).slice(2)
-               + destinationAddress.slice(2) + data.slice(2) + pad('0').slice(2)
+   hashInput = '0x1900' + txRelay.address.slice(2) + pad('0').slice(2) + pad(nonce.toString('16')).slice(2)
+               + destinationAddress.slice(2) + data.slice(2)
    hash = solsha3(hashInput)
    sig = lightwallet.signing.signMsgHash(lw, keyFromPw, hash, signingAddr)
    retVal.r = '0x'+sig.r.toString('hex')

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,9 +28,27 @@ abstract-leveldown@~2.6.1:
   dependencies:
     xtend "~4.0.0"
 
+acorn-dynamic-import@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
+  dependencies:
+    acorn "^4.0.3"
+
+acorn@^4.0.3:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
+
+acorn@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
+
 aes-js@^0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-0.2.4.tgz#94b881ab717286d015fa219e08fb66709dda5a3d"
+
+ajv-keywords@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
 ajv@^4.9.1:
   version "4.11.7"
@@ -38,6 +56,15 @@ ajv@^4.9.1:
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
+
+ajv@^5.1.5:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 ajv@^5.2.2:
   version "5.2.3"
@@ -63,6 +90,10 @@ amdefine@>=0.0.4:
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -110,6 +141,14 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+asn1.js@^4.0.0:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.9.2.tgz#8117ef4f7ed87cd8f89044b5bff97ac243a16c9a"
+  dependencies:
+    bn.js "^4.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -121,6 +160,12 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
 assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+
+assert@^1.1.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
+  dependencies:
+    util "0.10.3"
 
 async-each@^1.0.0:
   version "1.0.1"
@@ -892,6 +937,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big.js@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
+
 bignumber.js@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.0.2.tgz#2d1dc37ee5968867ecea90b6da4d16e68608d21d"
@@ -916,7 +965,7 @@ bindings@^1.2.1, bindings@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
 
-bip39@2.2.0, bip39@^2.2.0, bip39@~2.2.0:
+bip39@2.2.0, bip39@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.2.0.tgz#40e73f70674c267f148cdbf8374f2a50be166b0d"
   dependencies:
@@ -977,6 +1026,10 @@ bn.js@=2.0.4, bn.js@^2.0.0, bn.js@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-2.0.4.tgz#220a7cd677f7f1bfa93627ff4193776fe7819480"
 
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -1006,6 +1059,17 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
+browserify-aes@^1.0.0, browserify-aes@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.1.1.tgz#38b7ab55edb806ff2dcda1a7f1620773a477c49f"
+  dependencies:
+    buffer-xor "^1.0.3"
+    cipher-base "^1.0.0"
+    create-hash "^1.1.0"
+    evp_bytestokey "^1.0.3"
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
 browserify-aes@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.0.6.tgz#5e7725dbdef1fd5930d4ebab48567ce451c48a0a"
@@ -1016,11 +1080,52 @@ browserify-aes@^1.0.6:
     evp_bytestokey "^1.0.0"
     inherits "^2.0.1"
 
+browserify-cipher@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.0.tgz#9988244874bf5ed4e28da95666dcd66ac8fc363a"
+  dependencies:
+    browserify-aes "^1.0.4"
+    browserify-des "^1.0.0"
+    evp_bytestokey "^1.0.0"
+
+browserify-des@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.0.tgz#daa277717470922ed2fe18594118a175439721dd"
+  dependencies:
+    cipher-base "^1.0.1"
+    des.js "^1.0.0"
+    inherits "^2.0.1"
+
+browserify-rsa@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
+  dependencies:
+    bn.js "^4.1.0"
+    randombytes "^2.0.1"
+
 browserify-sha3@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/browserify-sha3/-/browserify-sha3-0.0.1.tgz#3ff34a3006ef15c0fb3567e541b91a2340123d11"
   dependencies:
     js-sha3 "^0.3.1"
+
+browserify-sign@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.0.4.tgz#aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298"
+  dependencies:
+    bn.js "^4.1.1"
+    browserify-rsa "^4.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.2"
+    elliptic "^6.0.0"
+    inherits "^2.0.1"
+    parse-asn1 "^5.0.0"
+
+browserify-zlib@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
+  dependencies:
+    pako "~1.0.5"
 
 bs58@=2.0.0:
   version "2.0.0"
@@ -1051,11 +1156,11 @@ buffer-shims@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
-buffer-xor@^1.0.2:
+buffer-xor@^1.0.2, buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
 
-buffer@^4.9.0, buffer@^4.9.1:
+buffer@^4.3.0, buffer@^4.9.0, buffer@^4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   dependencies:
@@ -1066,6 +1171,10 @@ buffer@^4.9.0, buffer@^4.9.1:
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+builtin-status-codes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
 bytewise-core@^1.2.2:
   version "1.2.3"
@@ -1087,6 +1196,10 @@ camelcase@^1.0.2, camelcase@^1.2.1:
 camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1115,7 +1228,7 @@ checkpoint-store@^1.1.0:
   dependencies:
     functional-red-black-tree "^1.0.1"
 
-chokidar@^1.6.0, chokidar@^1.6.1:
+chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -1139,6 +1252,13 @@ cipher-base@^1.0.0, cipher-base@^1.0.1:
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz#eeabf194419ce900da3018c207d212f2a6df0a07"
   dependencies:
     inherits "^2.0.1"
+
+cipher-base@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1203,9 +1323,19 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+console-browserify@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
+  dependencies:
+    date-now "^0.1.4"
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+
+constants-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
 convert-source-map@^1.1.0, convert-source-map@^1.5.0:
   version "1.5.0"
@@ -1223,6 +1353,13 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+create-ecdh@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.0.tgz#888c723596cdf7612f6498233eebd7a35301737d"
+  dependencies:
+    bn.js "^4.1.0"
+    elliptic "^6.0.0"
+
 create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.1.2.tgz#51210062d7bb7479f6c65bb41a92208b1d61abad"
@@ -1232,6 +1369,17 @@ create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2:
     ripemd160 "^1.0.0"
     sha.js "^2.3.6"
 
+create-hmac@^1.1.0, create-hmac@^1.1.2:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.6.tgz#acb9e221a4e17bdb076e90657c42b93e3726cf06"
+  dependencies:
+    cipher-base "^1.0.3"
+    create-hash "^1.1.0"
+    inherits "^2.0.1"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 create-hmac@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.4.tgz#d3fb4ba253eb8b3f56e39ea2fbcb8af747bd3170"
@@ -1239,11 +1387,35 @@ create-hmac@^1.1.4:
     create-hash "^1.1.0"
     inherits "^2.0.1"
 
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
+
+crypto-browserify@^3.11.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
+  dependencies:
+    browserify-cipher "^1.0.0"
+    browserify-sign "^4.0.0"
+    create-ecdh "^4.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.0"
+    diffie-hellman "^5.0.0"
+    inherits "^2.0.1"
+    pbkdf2 "^3.0.3"
+    public-encrypt "^4.0.0"
+    randombytes "^2.0.0"
+    randomfill "^1.0.3"
 
 crypto-js@^3.1.4, crypto-js@^3.1.5:
   version "3.1.8"
@@ -1253,11 +1425,21 @@ crypto-js@^3.1.9-1:
   version "3.1.9-1"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
 
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-now@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
 debug@2.2.0:
   version "2.2.0"
@@ -1324,6 +1506,13 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+des.js@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
+  dependencies:
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -1338,6 +1527,14 @@ diff@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
+diffie-hellman@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
+  dependencies:
+    bn.js "^4.1.0"
+    miller-rabin "^4.0.0"
+    randombytes "^2.0.0"
+
 directory-tree@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/directory-tree/-/directory-tree-2.0.0.tgz#c0a5fa0d642a1b1b7d10351b3c1db429770d8946"
@@ -1345,6 +1542,10 @@ directory-tree@^2.0.0:
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
+domain-browser@^1.1.1:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
 
 drbg.js@^1.0.1:
   version "1.0.1"
@@ -1378,7 +1579,7 @@ elliptic@^3.1.0:
     hash.js "^1.0.0"
     inherits "^2.0.1"
 
-elliptic@^6.2.3, elliptic@^6.3.1:
+elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.3.1:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"
   dependencies:
@@ -1389,6 +1590,10 @@ elliptic@^6.2.3, elliptic@^6.3.1:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+emojis-list@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -1402,7 +1607,16 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-errno@~0.1.1:
+enhanced-resolve@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.4.0"
+    object-assign "^4.0.1"
+    tapable "^0.2.7"
+
+errno@^0.1.3, errno@~0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
@@ -1431,6 +1645,58 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.35"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.35.tgz#18ee858ce6a3c45c7d79e91c15fcca9ec568494f"
+  dependencies:
+    es6-iterator "~2.0.1"
+    es6-symbol "~3.1.1"
+
+es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-map@^0.1.3:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-set "~0.1.5"
+    es6-symbol "~3.1.1"
+    event-emitter "~0.3.5"
+
+es6-set@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-symbol "3.1.1"
+    event-emitter "~0.3.5"
+
+es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+es6-weak-map@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
+
 escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
@@ -1450,6 +1716,15 @@ escodegen@1.8.x:
   optionalDependencies:
     source-map "~0.2.0"
 
+escope@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+  dependencies:
+    es6-map "^0.1.3"
+    es6-weak-map "^2.0.1"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 esprima@2.7.x, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
@@ -1458,11 +1733,18 @@ esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
+esrecurse@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.0.tgz#fa9568d98d3823f9a41d91e902dcab9ea6e5b163"
+  dependencies:
+    estraverse "^4.1.0"
+    object-assign "^4.0.1"
+
 estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
-estraverse@^4.2.0:
+estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -1561,28 +1843,11 @@ ethereumjs-block@^1.2.2, ethereumjs-block@~1.2.2:
     web3-provider-engine "https://github.com/sc-forks/provider-engine-sc.git#8.1.19"
     yargs "~3.29.0"
 
-ethereumjs-testrpc@^3.0.3:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/ethereumjs-testrpc/-/ethereumjs-testrpc-3.0.4.tgz#3f82decf0a116e6e7d7e34dd97a0b9aeadbb45e9"
+ethereumjs-testrpc@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.3.tgz#7a0b87bf3670f92f607f98fa6a78801d9741b124"
   dependencies:
-    async "~1.5.0"
-    bignumber.js "~2.1.4"
-    bip39 "~2.2.0"
-    ethereumjs-account "~2.0.4"
-    ethereumjs-block "~1.2.2"
-    ethereumjs-tx "1.1.2"
-    ethereumjs-util "~4.5.0"
-    ethereumjs-vm "~2.0.1"
-    ethereumjs-wallet "~0.6.0"
-    fake-merkle-patricia-tree "~1.0.1"
-    heap "~0.2.6"
-    merkle-patricia-tree "~2.1.2"
-    seedrandom "~2.4.2"
-    shelljs "~0.6.0"
-    solc "0.4.6"
-    web3 "~0.16.0"
-    web3-provider-engine "~8.1.0"
-    yargs "~3.29.0"
+    webpack "^3.0.0"
 
 ethereumjs-tx@1.1.2:
   version "1.1.2"
@@ -1605,7 +1870,7 @@ ethereumjs-tx@^1.1.1, ethereumjs-tx@^1.1.2, ethereumjs-tx@^1.2.0:
     ethereum-common "^0.0.18"
     ethereumjs-util "^5.0.0"
 
-ethereumjs-util@^4.0.0, ethereumjs-util@^4.0.1, ethereumjs-util@^4.4.0, ethereumjs-util@^4.5.0, ethereumjs-util@~4.5.0:
+ethereumjs-util@^4.0.0, ethereumjs-util@^4.0.1, ethereumjs-util@^4.4.0, ethereumjs-util@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz#3e9428b317eebda3d7260d854fddda954b1f1bc6"
   dependencies:
@@ -1656,20 +1921,6 @@ ethereumjs-vm@^2.0.2:
     functional-red-black-tree "^1.0.1"
     merkle-patricia-tree "^2.1.2"
 
-ethereumjs-vm@~2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-2.0.2.tgz#84e2372a5715a80a62f7f2a312f8c64537e8a842"
-  dependencies:
-    async "^2.1.2"
-    async-eventemitter "^0.2.2"
-    ethereum-common "0.0.18"
-    ethereumjs-account "^2.0.3"
-    ethereumjs-block "^1.2.2"
-    ethereumjs-util "^4.0.1"
-    fake-merkle-patricia-tree "^1.0.1"
-    functional-red-black-tree "^1.0.1"
-    merkle-patricia-tree "^2.1.2"
-
 ethereumjs-wallet@^0.6.0, ethereumjs-wallet@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-wallet/-/ethereumjs-wallet-0.6.0.tgz#82763b1697ee7a796be7155da9dfb49b2f98cfdb"
@@ -1705,11 +1956,41 @@ ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
+event-emitter@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+events@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+
 evp_bytestokey@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz#497b66ad9fef65cd7c08a6180824ba1476b66e53"
   dependencies:
     create-hash "^1.1.1"
+
+evp_bytestokey@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
+  dependencies:
+    md5.js "^1.3.4"
+    safe-buffer "^5.1.1"
+
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -1755,6 +2036,10 @@ fast-future@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fast-future/-/fast-future-1.0.2.tgz#8435a9aaa02d79248d17d704e76259301d99280a"
 
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
@@ -1779,6 +2064,12 @@ find-up@^1.0.0:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
+
+find-up@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
 
 for-each@^0.3.2, for-each@~0.3.2:
   version "0.3.2"
@@ -1878,6 +2169,10 @@ gauge@~2.7.1:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 getpass@^0.1.1:
   version "0.1.6"
@@ -1999,6 +2294,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2014,6 +2313,13 @@ hash-base@^2.0.0:
   resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-2.0.2.tgz#66ea1d856db4e8a5470cadf6fce23ae5244ef2e1"
   dependencies:
     inherits "^2.0.1"
+
+hash-base@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.0.3"
@@ -2072,6 +2378,10 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+
 iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
@@ -2088,6 +2398,10 @@ immediate@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
 
+indexof@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2099,7 +2413,7 @@ inherits@2, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inherits@=2.0.1, inherits@^2.0.1:
+inherits@2.0.1, inherits@=2.0.1, inherits@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
@@ -2179,6 +2493,10 @@ is-fullwidth-code-point@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
 is-function@^1.0.1, is-function@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
@@ -2213,7 +2531,7 @@ is-regex@^1.0.3:
   dependencies:
     has "^1.0.1"
 
-is-stream@^1.0.1:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2332,6 +2650,10 @@ jsesc@^1.3.0:
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+
+json-loader@^0.5.4:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -2540,6 +2862,34 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
+loader-runner@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
+
+loader-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -2621,6 +2971,13 @@ lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
+lru-cache@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 ltgt@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.0.tgz#b65ba5fcb349a29924c8e333f7c6a5562f2e4842"
@@ -2628,6 +2985,19 @@ ltgt@^2.1.2:
 ltgt@~2.1.1, ltgt@~2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.1.3.tgz#10851a06d9964b971178441c23c9e52698eece34"
+
+md5.js@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.4.tgz#e9bdbde94a20a5ac18b04340fc5764d5b09d901d"
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  dependencies:
+    mimic-fn "^1.0.0"
 
 memdown@^1.0.0:
   version "1.2.4"
@@ -2638,6 +3008,13 @@ memdown@^1.0.0:
     immediate "^3.2.3"
     inherits "~2.0.1"
     ltgt "~2.1.3"
+
+memory-fs@^0.4.0, memory-fs@~0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
+  dependencies:
+    errno "^0.1.3"
+    readable-stream "^2.0.1"
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -2674,6 +3051,13 @@ micromatch@^2.1.5:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
+miller-rabin@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
+  dependencies:
+    bn.js "^4.0.0"
+    brorand "^1.0.1"
+
 mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
@@ -2683,6 +3067,10 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
     mime-db "~1.27.0"
+
+mimic-fn@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -2727,7 +3115,7 @@ mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
 
-mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -2790,6 +3178,34 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-libs-browser@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
+  dependencies:
+    assert "^1.1.1"
+    browserify-zlib "^0.2.0"
+    buffer "^4.3.0"
+    console-browserify "^1.1.0"
+    constants-browserify "^1.0.0"
+    crypto-browserify "^3.11.0"
+    domain-browser "^1.1.1"
+    events "^1.0.0"
+    https-browserify "^1.0.0"
+    os-browserify "^0.3.0"
+    path-browserify "0.0.0"
+    process "^0.11.10"
+    punycode "^1.2.4"
+    querystring-es3 "^0.2.0"
+    readable-stream "^2.3.3"
+    stream-browserify "^2.0.1"
+    stream-http "^2.7.2"
+    string_decoder "^1.0.0"
+    timers-browserify "^2.0.4"
+    tty-browserify "0.0.0"
+    url "^0.11.0"
+    util "^0.10.3"
+    vm-browserify "0.0.4"
 
 node-nailgun-client@^0.1.0:
   version "0.1.0"
@@ -2858,6 +3274,12 @@ normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
 npmlog@^4.0.1, npmlog@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
@@ -2882,7 +3304,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.0, object-assign@^4.1.0:
+object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2933,6 +3355,10 @@ original-require@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/original-require/-/original-require-1.0.1.tgz#0f130471584cd33511c5ec38c8d59213f9ac5e20"
 
+os-browserify@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
+
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
@@ -2942,6 +3368,14 @@ os-locale@^1.4.0:
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
   dependencies:
     lcid "^1.0.0"
+
+os-locale@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+  dependencies:
+    execa "^0.7.0"
+    lcid "^1.0.0"
+    mem "^1.1.0"
 
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
@@ -2962,9 +3396,37 @@ output-file-sync@^1.1.0:
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-limit@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
 pako@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.3.tgz#5f515b0c6722e1982920ae8005eacb0b7ca73ccf"
+
+pako@~1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
+
+parse-asn1@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.0.tgz#37c4f9b7ed3ab65c74817b5f2480937fbf97c712"
+  dependencies:
+    asn1.js "^4.0.0"
+    browserify-aes "^1.0.0"
+    create-hash "^1.1.0"
+    evp_bytestokey "^1.0.0"
+    pbkdf2 "^3.0.3"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -2988,15 +3450,27 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+path-browserify@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
   dependencies:
     pinkie-promise "^2.0.0"
 
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -3009,6 +3483,12 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
 
 pbkdf2@^3.0.0, pbkdf2@^3.0.3:
   version "3.0.12"
@@ -3084,6 +3564,10 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+
 process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
@@ -3095,6 +3579,20 @@ prr@~0.0.0:
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+public-encrypt@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.0.tgz#39f699f3a46560dd5ebacbca693caf7c65c18cc6"
+  dependencies:
+    bn.js "^4.1.0"
+    browserify-rsa "^4.0.0"
+    create-hash "^1.1.0"
+    parse-asn1 "^5.0.0"
+    randombytes "^2.0.1"
 
 pull-cat@^1.1.9:
   version "1.1.11"
@@ -3140,13 +3638,25 @@ pump@^1.0.0, pump@^1.0.1:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^1.4.1:
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+
+punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+querystring-es3@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
 randomatic@^1.1.3:
   version "1.1.6"
@@ -3155,9 +3665,22 @@ randomatic@^1.1.3:
     is-number "^2.0.2"
     kind-of "^3.0.2"
 
+randombytes@^2.0.0, randombytes@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.5.tgz#dc009a246b8d09a177b4b7a0ae77bc570f4b1b79"
+  dependencies:
+    safe-buffer "^5.1.0"
+
 randombytes@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.3.tgz#674c99760901c3c4112771a31e521dc349cc09ec"
+
+randomfill@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.3.tgz#b96b7df587f01dd91726c418f30553b1418e3d62"
+  dependencies:
+    randombytes "^2.0.5"
+    safe-buffer "^5.1.0"
 
 rc@^1.1.6, rc@^1.1.7:
   version "1.2.1"
@@ -3175,6 +3698,13 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -3182,6 +3712,14 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 readable-stream@^1.0.33, readable-stream@~1.0.15, readable-stream@~1.0.26:
   version "1.0.34"
@@ -3202,6 +3740,18 @@ readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
     string_decoder "~1.0.0"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.0.1, readable-stream@^2.2.6, readable-stream@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
@@ -3373,7 +3923,7 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
-ripemd160@^2.0.1:
+ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
   dependencies:
@@ -3387,6 +3937,10 @@ rlp@^2.0.0:
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
+safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
 scrypt-async@^1.2.0, scrypt-async@^1.3.0:
   version "1.3.1"
@@ -3448,6 +4002,10 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
+setimmediate@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
 sha.js@^2.3.6:
   version "2.4.8"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
@@ -3466,6 +4024,16 @@ sha3@^1.1.0:
   resolved "https://registry.yarnpkg.com/sha3/-/sha3-1.2.0.tgz#6989f1b70a498705876a373e2c62ace96aa9399a"
   dependencies:
     nan "^2.0.5"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shelljs@^0.7.4:
   version "0.7.8"
@@ -3521,15 +4089,6 @@ solc@0.4.15:
     memorystream "^0.3.1"
     require-from-string "^1.1.0"
     semver "^5.3.0"
-    yargs "^4.7.1"
-
-solc@0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.6.tgz#afa929a1ceafc0252cfbb4217c8e2b1dab139db7"
-  dependencies:
-    fs-extra "^0.30.0"
-    memorystream "^0.3.1"
-    require-from-string "^1.1.0"
     yargs "^4.7.1"
 
 solc@0.4.8:
@@ -3606,6 +4165,10 @@ solparse@^1.2.7:
     pegjs "^0.10.0"
     yargs "^4.6.0"
 
+source-list-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
+
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
@@ -3628,11 +4191,19 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+source-map@^0.5.3:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
 source-map@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -3667,6 +4238,23 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+stream-browserify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
+  dependencies:
+    inherits "~2.0.1"
+    readable-stream "^2.0.2"
+
+stream-http@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.2.tgz#40a050ec8dc3b53b33d9909415c02c0bf1abfbad"
+  dependencies:
+    builtin-status-codes "^3.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.2.6"
+    to-arraybuffer "^1.0.0"
+    xtend "^4.0.0"
+
 stream-to-pull-stream@^1.7.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz#757609ae1cebd33c7432d4afbe31ff78650b9dde"
@@ -3682,6 +4270,13 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+string-width@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
 string.prototype.trim@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
@@ -3689,6 +4284,12 @@ string.prototype.trim@~1.1.2:
     define-properties "^1.1.2"
     es-abstract "^1.5.0"
     function-bind "^1.0.2"
+
+string_decoder@^1.0.0, string_decoder@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"
@@ -3710,11 +4311,25 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
 strip-hex-prefix@1.0.0:
   version "1.0.0"
@@ -3745,6 +4360,16 @@ supports-color@^3.1.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+supports-color@^4.2.1:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  dependencies:
+    has-flag "^2.0.0"
+
+tapable@^0.2.7:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
 
 tape@^4.4.0:
   version "4.6.3"
@@ -3814,11 +4439,21 @@ through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
+timers-browserify@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.4.tgz#96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6"
+  dependencies:
+    setimmediate "^1.0.4"
+
 tmp@0.0.31:
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
   dependencies:
     os-tmpdir "~1.0.1"
+
+to-arraybuffer@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
 to-fast-properties@^1.0.1:
   version "1.0.2"
@@ -3884,6 +4519,10 @@ truffle@^3.4.11:
     original-require "^1.0.1"
     solc "0.4.15"
 
+tty-browserify@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -3926,7 +4565,7 @@ typewiselite@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/typewiselite/-/typewiselite-1.0.0.tgz#c8882fa1bb1092c06005a97f34ef5c8508e3664e"
 
-uglify-js@^2.6:
+uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
@@ -3939,6 +4578,14 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
+uglifyjs-webpack-plugin@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz#b951f4abb6bd617e66f63eb891498e391763e309"
+  dependencies:
+    source-map "^0.5.6"
+    uglify-js "^2.8.29"
+    webpack-sources "^1.0.1"
+
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
@@ -3950,6 +4597,13 @@ unorm@^1.3.3:
 unzip-response@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
+
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 user-home@^1.1.1:
   version "1.1.1"
@@ -3966,6 +4620,12 @@ utf8@^2.1.1:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+util@0.10.3, util@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  dependencies:
+    inherits "2.0.1"
 
 uuid@^2.0.1:
   version "2.0.3"
@@ -3993,6 +4653,20 @@ verror@1.3.6:
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
     extsprintf "1.0.2"
+
+vm-browserify@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
+  dependencies:
+    indexof "0.0.1"
+
+watchpack@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.4.0.tgz#4a1472bcbb952bd0a9bb4036801f954dfb39faac"
+  dependencies:
+    async "^2.1.2"
+    chokidar "^1.7.0"
+    graceful-fs "^4.1.2"
 
 web3-provider-engine@^8.4.0:
   version "8.6.1"
@@ -4023,25 +4697,6 @@ web3-provider-engine@^8.4.0:
     ethereumjs-tx "^1.2.0"
     ethereumjs-util "^5.0.1"
     ethereumjs-vm-sc "https://github.com/sc-forks/ethereumjs-vm-sc.git"
-    isomorphic-fetch "^2.2.0"
-    request "^2.67.0"
-    semaphore "^1.0.3"
-    solc "^0.4.2"
-    tape "^4.4.0"
-    web3 "^0.16.0"
-    xhr "^2.2.0"
-    xtend "^4.0.1"
-
-web3-provider-engine@~8.1.0:
-  version "8.1.19"
-  resolved "https://registry.yarnpkg.com/web3-provider-engine/-/web3-provider-engine-8.1.19.tgz#3ccae95adecef55632e2a73bf3bee64b7e62fcf7"
-  dependencies:
-    async "^2.1.2"
-    clone "^2.0.0"
-    ethereumjs-block "^1.2.2"
-    ethereumjs-tx "^1.2.0"
-    ethereumjs-util "^5.0.1"
-    ethereumjs-vm "^2.0.2"
     isomorphic-fetch "^2.2.0"
     request "^2.67.0"
     semaphore "^1.0.3"
@@ -4089,6 +4744,40 @@ web3@^0.19.1:
     xhr2 "*"
     xmlhttprequest "*"
 
+webpack-sources@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.2.tgz#d0148ec083b3b5ccef1035a6b3ec16442983b27a"
+  dependencies:
+    source-list-map "^2.0.0"
+    source-map "~0.6.1"
+
+webpack@^3.0.0:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.8.1.tgz#b16968a81100abe61608b0153c9159ef8bb2bd83"
+  dependencies:
+    acorn "^5.0.0"
+    acorn-dynamic-import "^2.0.0"
+    ajv "^5.1.5"
+    ajv-keywords "^2.0.0"
+    async "^2.1.2"
+    enhanced-resolve "^3.4.0"
+    escope "^3.6.0"
+    interpret "^1.0.0"
+    json-loader "^0.5.4"
+    json5 "^0.5.1"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    mkdirp "~0.5.0"
+    node-libs-browser "^2.0.0"
+    source-map "^0.5.3"
+    supports-color "^4.2.1"
+    tapable "^0.2.7"
+    uglifyjs-webpack-plugin "^0.4.6"
+    watchpack "^1.4.0"
+    webpack-sources "^1.0.1"
+    yargs "^8.0.2"
+
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
@@ -4097,9 +4786,19 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+
 which@^1.1.1:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.9:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
     isexe "^2.0.0"
 
@@ -4179,12 +4878,22 @@ y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
 yargs-parser@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-2.4.1.tgz#85568de3cf150ff49fa51825f03a8c880ddcc5c4"
   dependencies:
     camelcase "^3.0.0"
     lodash.assign "^4.0.6"
+
+yargs-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs@^4.6.0, yargs@^4.7.1:
   version "4.8.1"
@@ -4204,6 +4913,24 @@ yargs@^4.6.0, yargs@^4.7.1:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
+
+yargs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
This PR addresses the front-running issue where anyone could make your tx fail and force you to resign the tx. It does so by changing it into a replay attach (changing if statement to require) and adds a whitelist so that you can use a trusted relayer. This means that only the trusted relayer will be able to preform the replay attack.

This also fixes #76 